### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/ExceptionDetectorUpdated/ExceptionDetectorUpdated.version
+++ b/GameData/ExceptionDetectorUpdated/ExceptionDetectorUpdated.version
@@ -1,6 +1,6 @@
 {
      "NAME":"ExceptionDetectorUpdated",
-	 "URL":"https://https://raw.githubusercontent.com/SlimJimDodger/ExceptionDetectorUpdated/master/GameData/ExceptionDetectorUpdated/ExceptionDetectorUpdated.version",
+	 "URL":"https://raw.githubusercontent.com/SlimJimDodger/ExceptionDetectorUpdated/master/GameData/ExceptionDetectorUpdated/ExceptionDetectorUpdated.version",
 	 "DOWNLOAD":"https://github.com/SlimJimDodger/ExceptionDetectorUpdated/releases",
      "CHANGE_LOG_URL":"https://raw.githubusercontent.com/SlimJimDodger/ExceptionDetectorUpdated/master/src/CHANGES.txt",
      "GITHUB":{


### PR DESCRIPTION
You only need one `https://` per URL.

Tagging @SlimJimDodger because GitHub doesn't reliably notify everyone of pull requests.